### PR TITLE
Add a simple but reasonably fast Redux version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mobx-react-devtools": "^4.2.10",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "react-redux": "next",
+    "react-redux": "^4.4.6",
     "redux": "^3.6.0"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -7,12 +7,14 @@ const MobXCanvas = require('bundle?lazy&name=MobXCanvas!./MobXCanvas')
 const ReduxCanvas = require('bundle?lazy&name=ReduxCanvas!./ReduxCanvas')
 const ReduxCanvasV2 = require('bundle?lazy&name=ReduxCanvasV2!./ReduxCanvasV2')
 const ReduxCanvasV3 = require('bundle?lazy&name=ReduxCanvasV3!./ReduxCanvasV3')
+const ReduxCanvasV4 = require('bundle?lazy&name=ReduxCanvasV4!./ReduxCanvasV4')
 
 const availableExperiments = {
   MobXCanvas,
   ReduxCanvas,
   ReduxCanvasV2,
-  ReduxCanvasV3
+  ReduxCanvasV3,
+  ReduxCanvasV4
 }
 
 class App extends Component {

--- a/src/ReduxCanvasV4.js
+++ b/src/ReduxCanvasV4.js
@@ -1,0 +1,61 @@
+import Immutable from 'immutable'
+import React from 'react'
+import { Provider, connect } from 'react-redux'
+import createStore from './createStore'
+import Pixel from './Pixel'
+
+// Reducer
+const store = createStore((state = Immutable.Map(), action) => {
+  if (action.type === 'TOGGLE') {
+    const key = action.i + ',' + action.j
+    return state.set(key, !state.get(key))
+  }
+  return state
+})
+
+const ACTIVE_PROPS = { active: true }
+const INACTIVE_PROPS = { active: false }
+
+// Connected pixel
+const ConnectedPixel = connect(
+  (initialState, initialProps) => {
+    const { i, j } = initialProps
+    return state => {
+      const active = state.get(i + ',' + j) || false
+      return active ? ACTIVE_PROPS : INACTIVE_PROPS
+    }
+  },
+  (initialState, initialProps) => (dispatch) => {
+    const { i, j } = initialProps
+    return {
+      onToggle() {
+        dispatch({ type: 'TOGGLE', i, j })
+      }
+    };
+  },
+  (stateProps, dispatchProps, ownProps) => ({
+    i: ownProps.i,
+    j: ownProps.j,
+    active: stateProps.active,
+    onToggle: dispatchProps.onToggle
+  })
+)(Pixel);
+
+// Root component
+function ReduxCanvas () {
+  const items = [ ]
+  for (let i = 0; i < 127; i++) {
+    for (let j = 0; j < 127; j++) {
+      items.push(<ConnectedPixel i={i} j={j} key={i + ',' + j} />)
+    }
+  }
+  return (
+    <Provider store={store}>
+      <div>
+        {items}
+      </div>
+    </Provider>
+  )
+}
+
+export default ReduxCanvas

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,8 +1,11 @@
 import { createStore as originalCreateStore } from 'redux'
 
 export function createStore (reducer) {
-  const extension = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-  return originalCreateStore(reducer, extension)
+  let enhancer
+  if (process.env.NODE_ENV !== 'production' && window.__REDUX_DEVTOOLS_EXTENSION__) {
+    enhancer = window.__REDUX_DEVTOOLS_EXTENSION__()
+  }
+  return originalCreateStore(reducer, enhancer)
 }
 
 export default createStore


### PR DESCRIPTION
It's less efficient than V3 but also way simpler.
Relies on memoization of props (which is something you want to do in intensive apps).

This gives me ~20ms for going through 32K nodes which IMO is good enough for most real apps.

I used `react-redux@4.x` because it is the latest stable version and the one I optimized. I haven't participated in the 5.x effort and can't say if it is optimal for this scenario (but it does seem 1.5-2x slower).